### PR TITLE
Update 7-exercise-reader.go

### DIFF
--- a/7-exercise-reader.go
+++ b/7-exercise-reader.go
@@ -6,11 +6,11 @@ type MyReader struct{}
 
 // TODO: Add a Read([]byte) (int, error) method to MyReader.
 func (r MyReader) Read(b []byte) (n int, err error) {
-	// Infinite flux of A
-	b[0] = 'A'
-
-	// Number of bits read, error
-	return 1, nil
+    s = s[:cap(s)];
+    for i := range s {
+        s[i] = 'A'
+    }
+    return cap(s), nil
 }
 
 func main() {

--- a/7-exercise-reader.go
+++ b/7-exercise-reader.go
@@ -5,7 +5,7 @@ import "github.com/dupoxy/go-tour-fr/reader"
 type MyReader struct{}
 
 // TODO: Add a Read([]byte) (int, error) method to MyReader.
-func (r MyReader) Read(b []byte) (n int, err error) {
+func (r MyReader) Read(s []byte) (n int, err error) {
     s = s[:cap(s)];
     for i := range s {
         s[i] = 'A'


### PR DESCRIPTION
That is very inefficient since it requires a function call for each byte read. Instead fill the passed slice to capacity with A's as in my solution.